### PR TITLE
Topic/#27-kawazoe

### DIFF
--- a/app/assets/javascripts/vue/view_models/work_index.coffee
+++ b/app/assets/javascripts/vue/view_models/work_index.coffee
@@ -63,7 +63,7 @@ ViewModels.WorkIndex = Vue.extend
       .done (res) =>
         @works = res.works
     # 対象年月日の作業内容を取得
-    getTagetYmd4Note: (date) ->
+    getNote: (date) ->
       ret = _.find @works, (work) =>
         @isSettled(date)
       ret = if ret? then ret.note else ""

--- a/app/assets/javascripts/vue/view_models/work_index.coffee
+++ b/app/assets/javascripts/vue/view_models/work_index.coffee
@@ -62,3 +62,8 @@ ViewModels.WorkIndex = Vue.extend
         async: false
       .done (res) =>
         @works = res.works
+    # 対象年月日の作業内容を取得
+    getTagetYmd4Note: (date) ->
+      ret = _.find @works, (work) =>
+        @isSettled(date)
+      ret = if ret? then ret.note else ""

--- a/app/assets/stylesheets/works.scss
+++ b/app/assets/stylesheets/works.scss
@@ -66,7 +66,7 @@
         min-height: 60px;
         &.settled {
           background-color: #eaeaea;
-          & .note {
+          .note {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/app/assets/stylesheets/works.scss
+++ b/app/assets/stylesheets/works.scss
@@ -66,6 +66,11 @@
         min-height: 60px;
         &.settled {
           background-color: #eaeaea;
+          & .note {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
         }
       }
     }

--- a/app/views/works/index.html.slim
+++ b/app/views/works/index.html.slim
@@ -15,4 +15,4 @@
     div.calendar-day
       section.day v-for="date in dates" :class="{ 'settled': isSettled(date) }"
         p.title v-text="date.format('D')"
-        p.note v-text="getTagetYmd4Note(date)"
+        p.note v-text="getNote(date)"

--- a/app/views/works/index.html.slim
+++ b/app/views/works/index.html.slim
@@ -15,3 +15,4 @@
     div.calendar-day
       section.day v-for="date in dates" :class="{ 'settled': isSettled(date) }"
         p.title v-text="date.format('D')"
+        p.note v-text="getTagetYmd4Note(date)"


### PR DESCRIPTION
## 関連
#27
## 概要

カレンダーに作業内容を表示する
## UI

[カンプ]
ハードコピーをはる
![image](https://cloud.githubusercontent.com/assets/4644540/13109891/8f54e992-d5bf-11e5-9ae9-4cbad11726e0.png)
[実装]
![image](https://cloud.githubusercontent.com/assets/4644540/13109912/b8e59c8e-d5bf-11e5-908d-1d2c388b7872.png)
## 動作確認
- [x] 画面上の該当日付に作業内容が表示されていること
- [x] はみ出した文字列に「...」が表示されていること
