### PR TITLE
Topic/#55-kawazoe

### DIFF
--- a/app/assets/javascripts/vue/view_models/work_index.coffee
+++ b/app/assets/javascripts/vue/view_models/work_index.coffee
@@ -47,9 +47,8 @@ ViewModels.WorkIndex = Vue.extend
       moment("#{@year}/#{@month}/1", 'YYYY/M/D')
     # 登録済みかいなか
     isSettled: (date) ->
-      ret = _.find @works, (work) =>
-        moment(work.started_at, 'YYYY/M/D h:mm').format('YYYYMMDD') == date.format('YYYYMMDD')
-      ret?
+      ret = @getWork(date)
+      ret = if Object.keys(ret).length != 0 then true else false
     # 登録済みの勤務データを取得
     getWorks: ->
       params =
@@ -62,8 +61,8 @@ ViewModels.WorkIndex = Vue.extend
         async: false
       .done (res) =>
         @works = res.works
-    # 対象年月日の作業内容を取得
-    getNote: (date) ->
+    # 対象年月日の勤務データを取得
+    getWork: (date) ->
       ret = _.find @works, (work) =>
-        @isSettled(date)
-      ret = if ret? then ret.note else ""
+        moment(work.started_at, 'YYYY/M/D h:mm').format('YYYYMMDD') == date.format('YYYYMMDD')
+      ret = if ret? then ret else {}

--- a/app/assets/javascripts/vue/view_models/work_index.coffee
+++ b/app/assets/javascripts/vue/view_models/work_index.coffee
@@ -47,8 +47,7 @@ ViewModels.WorkIndex = Vue.extend
       moment("#{@year}/#{@month}/1", 'YYYY/M/D')
     # 登録済みかいなか
     isSettled: (date) ->
-      ret = @getWork(date)
-      ret = if Object.keys(ret).length != 0 then true else false
+      Object.keys(@getWork(date)).length != 0
     # 登録済みの勤務データを取得
     getWorks: ->
       params =

--- a/app/views/works/index.html.slim
+++ b/app/views/works/index.html.slim
@@ -15,4 +15,4 @@
     div.calendar-day
       section.day v-for="date in dates" :class="{ 'settled': isSettled(date) }"
         p.title v-text="date.format('D')"
-        p.note v-text="getNote(date)"
+        p.note v-text="getWork(date).note"


### PR DESCRIPTION
## 関連
#55
## 概要

作業内容を取得する際に該当の作業内容ではなく最初に取得した作業内容が
表示されてしまう

[実装]
![image](https://cloud.githubusercontent.com/assets/4644540/13467951/d8e5843e-e0e3-11e5-9701-62feac84a940.png)
## 動作確認
- [x] 画面上の該当日付に対応する作業内容が表示されていること
